### PR TITLE
Add the environment to the slack message.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/rotate/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/rotate/Lambda.scala
@@ -2,6 +2,8 @@ package uk.gov.nationalarchives.rotate
 
 import com.amazonaws.services.lambda.runtime.Context
 import org.keycloak.admin.client.Keycloak
+import uk.gov.nationalarchives.rotate.ApplicationConfig.environment
+import uk.gov.nationalarchives.rotate.MessageSender.Message
 
 import java.io.{InputStream, OutputStream}
 import scala.annotation.unused
@@ -13,7 +15,9 @@ class Lambda() {
   val rotateRealmKeys: RotateRealmKeys = RotateRealmKeys(client)
 
   def handleRequest(@unused input: InputStream, @unused output: OutputStream, @unused context: Context): Unit = {
-    messageSender.sendMessages(rotateClientSecrets.rotate())
-    messageSender.sendMessages(rotateRealmKeys.rotate() :: Nil)
+    val secretRotationMessages: List[Message] = rotateClientSecrets.rotate()
+    val realmKeyRotationMessage: Message = rotateRealmKeys.rotate()
+    val messagesHeader: Message = Message(s"Keycloak rotation has been run for environment $environment")
+    messageSender.sendMessages(List(messagesHeader, realmKeyRotationMessage) ::: secretRotationMessages)
   }
 }


### PR DESCRIPTION
This means we can stop playing the fun "which environment is this for"
game.
