### PR TITLE
Add `tdr-user-read` to secrets rotation list

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/rotate/RotateClientSecrets.scala
+++ b/src/main/scala/uk/gov/nationalarchives/rotate/RotateClientSecrets.scala
@@ -75,7 +75,7 @@ object RotateClientSecrets {
     "tdr-reporting"-> s"/$environment/keycloak/reporting_client/secret",
     "tdr-rotate-secrets"-> s"/$environment/keycloak/rotate_secrets_client/secret",
     "tdr-user-admin"-> s"/$environment/keycloak/user_admin_client/secret",
-    "tdr-rotate-secrets" -> s"/$environment/keycloak/rotate_secrets_client/secret",
+    "tdr-user-read"-> s"/$environment/keycloak/user_read/secret"
   )
   def apply(client: Keycloak) = new RotateClientSecrets(client, ssmClient, ecsClient, environment, clients)
 }


### PR DESCRIPTION
I've created a new tdr-user-read client on intg that has view-users permissions. 

I still need to manually add the secret to parameter store once the TNA login works again